### PR TITLE
Fix possible crash in Copy From for partition tables

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -3844,9 +3844,13 @@ CopyFrom(CopyState cstate)
 				int relnatts;
 
 				if (!resultRelInfo->ri_resultSlot)
+				{
+					MemoryContextSwitchTo(estate->es_query_cxt);
 					resultRelInfo->ri_resultSlot =
 						MakeSingleTupleTableSlot(resultRelInfo->ri_RelationDesc->rd_att);
-
+					MemoryContextSwitchTo(GetPerTupleMemoryContext(estate));
+				}
+				
 				relnatts = resultRelInfo->ri_RelationDesc->rd_att->natts;
 				slot = resultRelInfo->ri_resultSlot;
 				ExecClearTuple(slot);


### PR DESCRIPTION
Master having mode as COPY_DISPATCH may improperly allocate the TupleTableSlot for a new ResultRelInfo of one partition on the per-tuple memory context. This can happen in the existence of ResultRelInfo::ri_partInsertMap. This causes crash because the per-tuple context will be reset for each tuple iteration. It should be using the per-query context.

Reproduce the crash using the following SQL commands:

    DROP TABLE IF EXISTS partition_test;
    
    CREATE TABLE partition_test
    (
      id INT,
      tm TIMESTAMP
    )
    DISTRIBUTED BY (id)
    PARTITION BY RANGE(tm)
    (
    PARTITION p2019 START ('2019-01-01'::TIMESTAMP) END ('2020-01-01'::TIMESTAMP),
    DEFAULT PARTITION extra
    );
    
    ALTER TABLE partition_test ADD COLUMN dd TIMESTAMP;
    ALTER TABLE partition_test DROP COLUMN dd;
    ALTER TABLE partition_test ADD COLUMN dd TEXT;
    
    ALTER TABLE partition_test SPLIT DEFAULT PARTITION START ('2020-01-01'::TIMESTAMP) END ('2021-01-01'::TIMESTAMP)
     INTO (PARTITION p2020, DEFAULT PARTITION);
    
    COPY (SELECT generate_series, '2020-12-20'::TIMESTAMP, 'ABCDEF' FROM generate_series(1, 10000)) TO '/tmp/partition_test.txt';
    COPY partition_test FROM '/tmp/partition_test.txt';

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
